### PR TITLE
Days fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: op3r
 Title: R Interface to the OP3 API
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Eric", "Nantz", , "theRcast@gmail.com", role = c("aut", "cre")),
     person("John", "Spurlock", role = "ctb", comment = "Author of OP3 project"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# op3r 0.1.1
+
+## Bug Fixes
+
+* Derive the number of days with at least one bot download of a podcast's episodes into a new column called `daysBotDownloads` in the `op3_downloads_show()` result.
+
 # op3r 0.1.0
 
 * Initial release of the package on GitHub and R-Universe

--- a/R/queries.R
+++ b/R/queries.R
@@ -191,7 +191,7 @@ op3_downloads_show <- function(show_id, nest_downloads = TRUE) {
   # create tibbles out of each show supplied
   download_list <- purrr::map(result_json$showDownloadCounts, ~{
     df <- tibble::tibble(
-      days = .x$days,
+      daysBotDownloads = get_bot_downloads(.x$days),
       monthlyDownloads = .x$monthlyDownloads,
       weeklyAvgDownloads = .x$weeklyAvgDownloads,
       numWeeks = .x$numWeeks,

--- a/R/utils.R
+++ b/R/utils.R
@@ -48,3 +48,8 @@ assert_valid_limit <- function(limit, max_limit = 20000) {
     )
   }
 }
+
+get_bot_downloads <- function(day_string) {
+  x <- stringr::str_split_1(day_string, "") |> as.numeric()
+  return(sum(x))
+}


### PR DESCRIPTION
## Bug Fixes

* Derive the number of days with at least one bot download of a podcast's episodes into a new column called `daysBotDownloads` in the `op3_downloads_show()` result.